### PR TITLE
chore(deps): handle relocation of set_sys_clock_khz

### DIFF
--- a/sw/picocart64_v1/picocart64_v1.c
+++ b/sw/picocart64_v1/picocart64_v1.c
@@ -15,6 +15,12 @@
 #include "hardware/flash.h"
 #include "hardware/irq.h"
 
+#if PICO_SDK_VERSION_MAJOR >= 2 || (PICO_SDK_VERSION_MAJOR == 1 && (PICO_SDK_VERSION_MINOR > 6 || PICO_SDK_VERSION_MINOR == 6 && PICO_SDK_VERSION_REVISION >= 2 ))
+/* https://github.com/raspberrypi/pico-sdk/issues/712 */
+#include "hardware/clocks.h"
+#endif
+
+
 #include "stdio_async_uart.h"
 
 #include "n64_cic.h"


### PR DESCRIPTION
set_sys_clock_khz was relocated to <hardware/clocks.h> in 1.6.2+